### PR TITLE
Duplicate entries in the exported CSV fix

### DIFF
--- a/content/content.index.php
+++ b/content/content.index.php
@@ -389,7 +389,7 @@ class contentExtensionImportcsvIndex extends AdministrationPage
         for($offset = 0; $offset < $total; $offset += 100)
 
         {
-            $entries = EntryManager::fetch(null, $sectionID, 100, $offset, $where, $joins);
+            $entries = EntryManager::fetch(null, $sectionID, 100, $offset, $where, $joins, false, true, null, false);
             foreach ($entries as $entry) {
                 $line = array();
                 foreach ($fields as $field) {

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -22,7 +22,7 @@ class extension_importcsv extends Extension
         }
     }
 
-    public function update()
+    public function update($previousVersion = false)
     {
         if (file_exists(TMP.'/importcsv.csv')) {
             @unlink(TMP.'/importcsv.csv');


### PR DESCRIPTION
By default, the CSV entries are sorted with core fetch function so it'll give duplicate entries when exported. This is a tricky fix (Might not be the best thing to do as I don't have a complete idea about the extension)