### PR TITLE
Fixes for upload driver

### DIFF
--- a/drivers/ImportDriver_upload.php
+++ b/drivers/ImportDriver_upload.php
@@ -34,11 +34,11 @@ class ImportDriver_upload extends ImportDriver_default
             $sql = 'SELECT COUNT(*) AS `total` FROM `tbl_entries_data_' . $this->field->get('id') . '` WHERE `file` = \'' . $filename . '\';';
             $total = Symphony::Database()->fetchVar('total', 0, $sql);
             if ($total == 0) {
-                $fileData = $this->field->processRawFieldData($value, $this->field->__OK__);
-                $fileData['file'] = trim($filename);
-                $fileData['size'] = filesize(DOCROOT . $destination . '/' . $value);
-                $fileData['mimetype'] = mime_content_type(DOCROOT . $destination . '/' . $value);
-                $fileData['meta'] = serialize($this->field->getMetaInfo(DOCROOT . $destination . '/' . $value, $fileData['mimetype']));
+                $fileData = $this->field->processRawFieldData(trim($value), $this->field->__OK__);
+                $fileData['file'] = trim($value);
+                $fileData['size'] = filesize(DOCROOT . $destination . '/' . trim($value));
+                $fileData['mimetype'] = mime_content_type(DOCROOT . $destination . '/' . trim($value));
+                $fileData['meta'] = serialize($this->field->getMetaInfo(DOCROOT . $destination . '/' . trim($value), $fileData['mimetype']));
 
                 return $fileData;
             } else {
@@ -48,11 +48,11 @@ class ImportDriver_upload extends ImportDriver_default
         } else {
             // File is stored in the CSV, but does not exists. Save it anyway, for database sake:
             if (!empty($value)) {
-                $fileData = $this->field->processRawFieldData($value, $this->field->__OK__);
-                $fileData['file'] = trim($filename);
-                $fileData['size'] = filesize(DOCROOT . $destination . '/' . $value);
-                $fileData['mimetype'] = ''; // mime_content_type(DOCROOT . $destination . '/' . $value);
-                $fileData['meta'] = serialize($this->field->getMetaInfo(DOCROOT . $destination . '/' . $value, $fileData['mimetype']));
+                $fileData = $this->field->processRawFieldData(trim($value), $this->field->__OK__);
+                $fileData['file'] = trim($value);
+                $fileData['size'] = filesize(DOCROOT . $destination . '/' . trim($value));
+                $fileData['mimetype'] = ''; // mime_content_type(DOCROOT . $destination . '/' . trim($value));
+                $fileData['meta'] = serialize($this->field->getMetaInfo(DOCROOT . $destination . '/' . trim($value), $fileData['mimetype']));
 
                 return $fileData;
             }


### PR DESCRIPTION
When `$value` was not always trimmed it caused a server 500 error on import.  The error log was showing a line break e.g.

```
Fatal Error: ErrorException 0 - filesize(): stat failed for /path-redacted/workspace/images/
filename.jpg on line 39 of /path-redacted/extensions/importcsv/drivers/ImportDriver_upload.php
```

Also, the resulting import set a path for `$fileData['file']` because `$filename` was used I believe, so Symphony was complaining the file did not exist even though it was there and the link worked.  Undoing the import, changing `$fileData['file']` to take the trimmed `$value` made the import work afterwards.